### PR TITLE
Generic error types

### DIFF
--- a/Control/Watchdog.hs
+++ b/Control/Watchdog.hs
@@ -152,17 +152,13 @@ watchdogWith conf action = evalStateT (runWA action) conf
 -- | Set the initial delay in microseconds. The first time the watchdog pauses
 -- will be for this amount of time. The default is 1 second.
 setInitialDelay :: Int -> WatchdogAction e ()
-setInitialDelay delay = do
-    conf <- get
-    put conf { wcInitialDelay = delay }
+setInitialDelay delay = modify (\conf -> conf { wcInitialDelay = delay })
 
 -- | Set the maximum delay in microseconds. When a task fails to execute
 -- properly multiple times in quick succession, the delay is doubled each time
 -- until it stays constant at the maximum delay. The default is 300 seconds.
 setMaximumDelay :: Int -> WatchdogAction e ()
-setMaximumDelay delay = do
-    conf <- get
-    put conf { wcMaximumDelay = delay }
+setMaximumDelay delay = modify (\conf -> conf { wcMaximumDelay = delay })
 
 -- | If a task has been running for some time, the watchdog will consider
 -- the next failure to be something unrelated and reset the waiting time
@@ -170,17 +166,13 @@ setMaximumDelay delay = do
 -- microseconds that needs to pass before the watchdog will consider a task to
 -- be successfully running. The default is 30 seconds.
 setResetDuration :: Int -> WatchdogAction e ()
-setResetDuration duration = do
-    conf <- get
-    put conf { wcResetDuration = duration }
+setResetDuration duration = modify (\conf -> conf { wcResetDuration = duration })
 
 -- | Set the number of retries after which the watchdog will give up and
 -- return with a permanent error. This setting is only used in combination with
 -- 'watchImpatiently'. The default is 10.
 setMaximumRetries :: Integer -> WatchdogAction e ()
-setMaximumRetries retries = do
-    conf <- get
-    put conf { wcMaximumRetries = retries }
+setMaximumRetries retries = modify (\conf -> conf { wcMaximumRetries = retries })
 
 -- | Set the logging action that will be called by the watchdog. The supplied
 -- function of type 'WatchdogLogger' will be provided with the error message of
@@ -188,9 +180,7 @@ setMaximumRetries retries = do
 -- delay' if the watchdog will now pause for the specified amount of time before
 -- trying again.  The default is 'defaultLogger'.
 setLoggingAction :: WatchdogLogger e -> WatchdogAction e ()
-setLoggingAction f = do
-    conf <- get
-    put conf { wcLoggingAction = f }
+setLoggingAction f = modify (\conf -> conf { wcLoggingAction = f })
 
 -- | Watch a task, restarting it potentially forever or until it returns with a
 -- result. The task should return an 'Either', where 'Left' in combination with

--- a/Control/Watchdog.hs
+++ b/Control/Watchdog.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 -- |
 -- How to use:
 --
@@ -104,6 +105,8 @@ module Control.Watchdog
 import Control.Applicative
 import Control.Concurrent
 import Control.Monad.State.Strict
+import Data.Monoid                ((<>))
+import Data.String                (IsString, fromString)
 import Data.Time
 
 data WatchdogState e = WatchdogState { wcInitialDelay   :: Int
@@ -265,16 +268,17 @@ silentLogger _ _ = return ()
 -- Watchdog: Error executing task (some error) - trying again immediately.
 -- Watchdog: Error executing task (some error) - waiting 1s before trying again.
 -- @
-formatWatchdogError :: String -- ^ Error message returned by the task.
-                    -> Maybe Int -- ^ Waiting time - if any - before trying again.
-                    -> String
+formatWatchdogError :: (IsString str, Monoid str)
+                       => str       -- ^ Error message returned by the task.
+                       -> Maybe Int -- ^ Waiting time - if any - before trying again.
+                       -> str
 formatWatchdogError taskErr Nothing =
-    "Watchdog: Error executing task (" ++ taskErr ++ ") - trying again immediately."
+    "Watchdog: Error executing task (" <> taskErr <> ") - trying again immediately."
 formatWatchdogError taskErr (Just delay) =
     let asNominalDiffTime :: NominalDiffTime    -- just to display it properly
         asNominalDiffTime = fromIntegral delay / 10 ^ (6 :: Integer)
-    in "Watchdog: Error executing task (" ++ taskErr ++ ") - waiting"
-        ++ " " ++ show asNominalDiffTime ++ " before trying again."
+    in "Watchdog: Error executing task (" <> taskErr <> ") - waiting"
+        <> " " <> fromString (show asNominalDiffTime) <> " before trying again."
 
 -- | Helper class which can be wrapped around a task.
 -- The task should return an 'Either', where Left in combination

--- a/watchdog.cabal
+++ b/watchdog.cabal
@@ -17,7 +17,7 @@ source-repository head
     location: https://github.com/javgh/watchdog
 
 library
-    build-depends: base == 4.*
+    build-depends: base >= 4.5 && < 5
                    , time >= 1.4 && < 1.9
                    , mtl >= 2.1 && < 2.3
     exposed-modules: Control.Watchdog


### PR DESCRIPTION
These changes allow for people to use other types for error messages easier.

For example, if you currently don't want any errors printed, you still have to convert error values into `String` (using `show` or `const ""`); this way you can use `watchdogBlank` instead.

Or you could use `Text` if you already have that as your error type rather than unpacking it (currently requires going through `watchdogBlank` still).