### PR TITLE
Bump version of time package

### DIFF
--- a/Control/Watchdog.hs
+++ b/Control/Watchdog.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 -- |
 -- How to use:
@@ -105,9 +106,11 @@ module Control.Watchdog
 import Control.Applicative
 import Control.Concurrent
 import Control.Monad.State.Strict
+#if !MIN_VERSION_base(4,9,0)
 import Data.Monoid                ((<>))
+#endif
 import Data.String                (IsString, fromString)
-import Data.Time
+import Data.Time                  (NominalDiffTime, diffUTCTime, getCurrentTime)
 
 data WatchdogState e = WatchdogState { wcInitialDelay   :: Int
                                      , wcMaximumDelay   :: Int

--- a/watchdog.cabal
+++ b/watchdog.cabal
@@ -18,7 +18,7 @@ source-repository head
 
 library
     build-depends: base >= 4.8 && < 5
-                   , time >= 1.4 && < 1.9
+                   , time >= 1.4 && < 1.13
                    , mtl >= 2.1 && < 2.3
     exposed-modules: Control.Watchdog
     ghc-options: -Wall


### PR DESCRIPTION
The version of GHC in Debian stable ("bullseye") is 8.8.4, corresponding to `base-4.13.0.0`.  However, `time-1.8.0.4` — the most recent version permitted by `watchdog` — has a constraint of `base < 4.13`, so `watchdog` does not build on Debian stable.

This change bumps the version of `time` to the most recent, whilst using the CPP extension to retain compatibility with GCC 7.10.1 (`base-4.8.0.0`).  I have built `watchdog` without errors using both GHC 7.10.1 and 8.8.4.

I'd be more than happy to submit a pull request without CPP and with a constraint `base >= 4.9` (the earliest in which `Data.Semigroup` and hence `<>` appears) if you would prefer that.

Thank you for `watchdog`!