### PR TITLE
Bump time and base versions

### DIFF
--- a/Control/Watchdog.hs
+++ b/Control/Watchdog.hs
@@ -105,7 +105,7 @@ module Control.Watchdog
 import Control.Applicative
 import Control.Concurrent
 import Control.Monad.State.Strict
-import Data.Monoid                ((<>))
+import Data.Semigroup             (Semigroup, (<>))
 import Data.String                (IsString, fromString)
 import Data.Time
 
@@ -262,7 +262,7 @@ silentLogger _ _ = return ()
 -- Watchdog: Error executing task (some error) - trying again immediately.
 -- Watchdog: Error executing task (some error) - waiting 1s before trying again.
 -- @
-formatWatchdogError :: (IsString str, Monoid str)
+formatWatchdogError :: (IsString str, Semigroup str)
                        => str       -- ^ Error message returned by the task.
                        -> Maybe Int -- ^ Waiting time - if any - before trying again.
                        -> str

--- a/watchdog.cabal
+++ b/watchdog.cabal
@@ -17,8 +17,8 @@ source-repository head
     location: https://github.com/javgh/watchdog
 
 library
-    build-depends: base >= 4.8 && < 5
-                   , time >= 1.4 && < 1.9
+    build-depends: base >= 4.9 && < 5
+                   , time >= 1.4 && < 1.13
                    , mtl >= 2.1 && < 2.3
     exposed-modules: Control.Watchdog
     ghc-options: -Wall


### PR DESCRIPTION
As discussed in #4, the version of GHC in Debian stable ("bullseye") is 8.8.4, corresponding to `base-4.13.0.0`. However, `time-1.8.0.4` — the most recent version permitted by `watchdog` — has a constraint of `base < 4.13`, so `watchdog` does not build on Debian stable.

This change bumps the version of time to the most recent, *without* using the CPP extension, per discussion in #4.  I have built `watchdog` without errors using both GHC 8.0.1 (corresponding to `base-4.9.0.0`) and 8.8.4.

Note that this change results in a build warning re the redundant import of `Data.Semigroup` on modern GHC, due to the `Semigroup` class making its way into the Prelude.

Thanks for the prompt response, and thank you again for `watchdog`!